### PR TITLE
Make sure we don't show any BP related content when season is off

### DIFF
--- a/news.txt
+++ b/news.txt
@@ -5,17 +5,17 @@
 //URL 0;https://forum.toribash.com/tori_shop_item.php?id=3598
 //STORE 0;3598
 
-NEWSID 0;
-TITLE 0;Toribash x Makeship
-SUBTITLE 0;Uke Plush is now available for preorders!
-IMAGE 0;makeship2.tga
-URL 0;https://www.toribash.com/makeship
+//NEWSID 0;
+//TITLE 0;Toribash x Makeship
+//SUBTITLE 0;Uke Plush is now available for preorders!
+//IMAGE 0;makeship2.tga
+//URL 0;https://www.toribash.com/makeship
 
-NEWSID 1;
-TITLE 0;Rags 2 Riches
-SUBTITLE 0;This is a chance for you marketeers to put your money where your mouth is and battle it out to earn the most TC!
-IMAGE 0;ragstoriches22.tga
-URL 0;https://forum.toribash.com/showthread.php?t=656540
+//NEWSID 1;
+//TITLE 0;Rags 2 Riches
+//SUBTITLE 0;This is a chance for you marketeers to put your money where your mouth is and battle it out to earn the most TC!
+//IMAGE 0;ragstoriches22.tga
+//URL 0;https://forum.toribash.com/showthread.php?t=656540
 
 NEWSID 2;
 TITLE 0;Leggang Statue

--- a/script/system/battlepass_manager.lua
+++ b/script/system/battlepass_manager.lua
@@ -148,6 +148,9 @@ function BattlePass:getUserData(viewElement)
 					break
 				end
 			end
+			if (Quests.QuestsData ~= nil) then
+				Quests:addBattlePassQuests()
+			end
 			if (viewElement and not viewElement.destroyed) then
 				BattlePass:showMain()
 			elseif (TB_MENU_MAIN_ISOPEN == 1 and TB_MENU_SPECIAL_SCREEN_ISOPEN == 0) then

--- a/script/system/quests_manager.lua
+++ b/script/system/quests_manager.lua
@@ -157,28 +157,40 @@ function Quests:getQuests()
 	end
 	file:close()
 
-	local loginRewardsAvailable = PlayerInfo:getLoginRewards().available
-	if (loginRewardsAvailable) then
-		table.insert(questData, {
-			id = 2000,
-			name = TB_MENU_LOCALIZED.QUESTSDAILYPLAYER,
-			description = "Log in and claim login rewards",
-			progresspercentage = loginRewardsAvailable and 0 or 1,
-			requirement = loginRewardsAvailable and 1 or 2,
-			progress = loginRewardsAvailable and 0 or 1,
-			claimed = not loginRewardsAvailable,
-			type = 0,
-			timeleft = -1,
-			modid = 0,
-			modname = '',
-			reward = 0,
-			rewardid = 0,
-			bp_xp = 5
-		})
-	end
-
 	---@type QuestData[]
 	Quests.QuestsData = table.qsort(questData, "progresspercentage", SORT_DESCENDING)
+
+	if (BattlePass.UserData) then
+		Quests:addBattlePassQuests()
+	end
+end
+
+---Adds hardcoded Battle Pass quests that automark themselves on completion
+function Quests:addBattlePassQuests()
+	for i,v in pairs(Quests.QuestsData) do
+		if (v.id == 2000) then
+			return
+		end
+	end
+
+	local loginRewardsAvailable = PlayerInfo:getLoginRewards().available
+	table.insert(Quests.QuestsData, {
+		id = 2000,
+		name = TB_MENU_LOCALIZED.QUESTSDAILYPLAYER,
+		description = "Log in and claim login rewards",
+		progresspercentage = loginRewardsAvailable and 0 or 1,
+		requirement = loginRewardsAvailable and 1 or 2,
+		progress = loginRewardsAvailable and 0 or 1,
+		claimed = not loginRewardsAvailable,
+		type = 0,
+		timeleft = -1,
+		modid = 0,
+		modname = '',
+		reward = 0,
+		rewardid = 0,
+		bp_xp = 5
+	})
+	Quests.QuestsData = table.qsort(Quests.QuestsData, "progresspercentage", SORT_DESCENDING)
 end
 
 ---Updates daily login quest status
@@ -785,7 +797,7 @@ function Quests:showQuestButton(quest, listingHolder, listElements, elementHeigh
 			})
 			shiftX = shiftX + questBPIcon.size.w
 		end
-		if (not quest.description and (quest.timeleft and quest.timeleft <= 0)) then
+		if (not quest.description and ((quest.timeleft and quest.timeleft <= 0) or quest.global)) then
 			questBackground:addChild({
 				pos = { questProgressOutline.shift.x + questProgressOutline.size.w + 10, questTitle.shift.y },
 				size = { questBackground.size.w - questProgressOutline.size.w - questProgressOutline.shift.x - 30 - shiftX, questTitle.size.h }


### PR DESCRIPTION
- Check for BP status when populating Quests data
- Make sure we show global quests' reward text correctly
- Refresh quests data after retrieving BP status if needed